### PR TITLE
Enable download attribute

### DIFF
--- a/src/javascript/squarify.js
+++ b/src/javascript/squarify.js
@@ -126,7 +126,7 @@ const drawImage = ({image}) => {
 
 	// Convert the canvas to a encoded dataURL to add to the download link.
 	dataURL = canvas.toDataURL();
-	// document.getElementById('target-link').download = 'borders--' + filename;
+	document.getElementById('target-link').download = 'borders--' + filename;
 	document.getElementById('target-link').href = dataURL;
 }
 


### PR DESCRIPTION
 - Adding the download attribute should ask the browser to download the file, rather than displaying it.
 - Download attribute [now supported in iOS 13](https://caniuse.com/#feat=download)