### PR TITLE
Fixes for changing the frame colour in Safari

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -104,7 +104,16 @@
             }
 
             .add-photo__input {
-                display: none;
+                bottom: 0;
+                clip-path: inset(50%);
+                clip: rect(0 0 0 0);
+                height: 1px;
+                left: 50%;
+                margin: 0;
+                overflow: hidden;
+                position: absolute;
+                white-space: nowrap;
+                width: 1px;
             }
 
             .button {

--- a/src/index.html
+++ b/src/index.html
@@ -117,20 +117,21 @@
             }
 
             .button {
+                align-items: center;
                 background: #ffffff linear-gradient(to top, rgba(0,0,0,0.25) 0%,rgba(0,0,0,0) 100%);
                 border: 1px solid rgba(0, 0, 0, 0.1);
                 box-sizing: border-box;
                 color: #000000;
                 cursor: pointer;
-                font-size: 1em;
-                padding: 1.25em 1em 1em 1em;
-                text-align: center;
-                text-decoration: none;
-                margin: 0;
-                width: 25%;
-
                 display: flex;
                 flex-direction: column;
+                font-size: 1em;
+                margin: 0;
+                padding: 1.25em 0.5em 1em 0.5em;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                width: 25%;
             }
 
             .button::before {

--- a/src/javascript/squarify.js
+++ b/src/javascript/squarify.js
@@ -56,8 +56,7 @@ backgroundColourInput.addEventListener('input', (event) => {
 	console.log(event.target.value)
 	if (event.target.disabled) return
 
-	backgroundColour = event.target.value ? event.target.value : '#f2aa3b'
-	console.log({backgroundColour})
+	backgroundColour = event.target.value ? event.target.value : '#ffffff'
 	drawImage({ image })
 })
 

--- a/src/javascript/squarify.js
+++ b/src/javascript/squarify.js
@@ -50,7 +50,7 @@ backgroundColourInput.id = 'change-background-colour'
 backgroundColourInput.className = 'add-photo__input'
 backgroundColourInput.type = 'color'
 backgroundColourInput.disabled = 'true'
-createToolbar.appendChild(backgroundColourInput)
+backgroundColourLabel.appendChild(backgroundColourInput)
 
 backgroundColourInput.addEventListener('input', (event) => {
 	console.log(event.target.value)

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -7,6 +7,7 @@ const precache = () => {
         './icons/download.svg',
         './icons/rotate.svg',
         './icons/upload.svg',
+        './icons/frame.svg',
         './javascript/app.js',
         './javascript/squarify.js'
       ]);


### PR DESCRIPTION
## What

Updates the way the inputs are hidden from `display: none` to the visually hidden trick; other minor layout tweaks and an update to the service worker cache list.

## Why

The ability to change the frame colour wasn't working in Safari because the input was not displayed. Switching to using the visually hidden method fixed this.